### PR TITLE
[fix] POST /actions 无动画

### DIFF
--- a/src/scene/OfficeScene.ts
+++ b/src/scene/OfficeScene.ts
@@ -16,7 +16,10 @@ import { MovementSystem } from '@/scene/systems/MovementSystem'
 import { AnimationSystem } from '@/scene/systems/AnimationSystem'
 import { OfficeSimulator } from '@/scene/simulation/OfficeSimulator'
 import { bindOfficeScene } from '@/scene/officeSceneBridge'
-import { notifyVisitMissionActivity } from '@/services/officeActionDispatcher'
+import {
+  hasPendingVisitQueue,
+  notifyVisitMissionActivity,
+} from '@/services/officeActionDispatcher'
 import { setOfficeAgents } from '@/store/officeStore'
 import {
   getOfficeBackgroundTexture,
@@ -246,6 +249,10 @@ export class OfficeScene {
       this.agentEntities,
     )
     this.pushDataToEntities()
+
+    // 先同步 store 并消费外部队列，再补 Demo，避免空闲窗口被自动工作流吞掉
+    setOfficeAgents(this.agents)
+    notifyVisitMissionActivity(this.agents)
     this.updateAutoWorkflow(dt)
 
     this.animation.update(this.agentEntities, dt)
@@ -253,12 +260,17 @@ export class OfficeScene {
     this.syncDeskOccupancy()
 
     setOfficeAgents(this.agents)
-    notifyVisitMissionActivity(this.agents)
   }
 
   private updateAutoWorkflow(dt: number) {
     this.autoWorkflowTimer -= dt
     if (this.autoWorkflowTimer > 0) return
+
+    // 外部 HTTP 拜访优先：有待执行命令时不启动新的 Demo 拜访
+    if (hasPendingVisitQueue()) {
+      this.autoWorkflowTimer = 0.35
+      return
+    }
 
     const activeCount = this.agents.filter((agent) => agent.mission).length
     if (activeCount >= AUTO_WORKFLOW_MAX_ACTIVE) {

--- a/src/services/officeActionDispatcher.ts
+++ b/src/services/officeActionDispatcher.ts
@@ -195,6 +195,11 @@ export function notifyVisitMissionActivity(agents: Agent[]) {
   wasMissionBusy = busy
 }
 
+/** 是否有尚未执行的外部拜访命令（供场景自动工作流让路） */
+export function hasPendingVisitQueue(): boolean {
+  return visitQueue.length > 0
+}
+
 export function getDispatchStats(): {
   mode: OfficeDispatchMode
   queueDepth: number


### PR DESCRIPTION
 -关键冲突在 [src/scene/OfficeScene.ts](src/scene/OfficeScene.ts) 的 tick 顺序：
 -afterMovement 可能刚好结束拜访 → agents 短暂 idle
updateAutoWorkflow 立刻再开 Demo 拜访（最多 2 路并发）
notifyVisitMissionActivity 后运行 → 永远看不到「busy → idle」，[drainQueueIfNeeded](src/services/officeActionDispatcher.ts) 不触发
 -因此控制台常见：[OfficeDispatch] queue: enqueued，但几乎没有 executing；页面上只有 Demo 自带动画，看不到你 POST 的 visitor:1 → host:5 与指定文案。
#分支名：main-fix-visit-animation
#修复方式：让外部动作优先于自动工作流，并调整每帧通知顺序。该功能以通过个人验证。


